### PR TITLE
feat: Add sub-bot functionality

### DIFF
--- a/plugins/bots.js
+++ b/plugins/bots.js
@@ -1,0 +1,26 @@
+import config from '../config.js';
+
+export default {
+    name: 'bots',
+    aliases: ['listbots', 'subbots'],
+    category: 'subbots',
+    description: 'Lista los sub-bots conectados.',
+
+    async execute({ sock: conn, msg: m }) {
+        const subBots = global.subBots || [];
+
+        if (subBots.length === 0) {
+            return conn.sendMessage(m.key.remoteJid, { text: "No hay sub-bots conectados." }, { quoted: m });
+        }
+
+        let response = `*Sub-Bots Conectados:*\n\n`;
+        subBots.forEach((bot, index) => {
+            const botUser = bot.sock.user;
+            const name = botUser.name || 'Sin Nombre';
+            const jid = botUser.id;
+            response += `${index + 1}. *Nombre:* ${name}\n   *JID:* ${jid}\n   *Owner:* ${bot.owner}\n\n`;
+        });
+
+        await conn.sendMessage(m.key.remoteJid, { text: response.trim() }, { quoted: m });
+    }
+}

--- a/plugins/serbot-code.js
+++ b/plugins/serbot-code.js
@@ -1,0 +1,308 @@
+import Baileys, { useMultiFileAuthState, DisconnectReason, makeCacheableSignalKeyStore, fetchLatestBaileysVersion, Browsers } from "@whiskeysockets/baileys"
+import qrcode from "qrcode"
+import NodeCache from "node-cache"
+import fs from "fs"
+import path from "path"
+import pino from 'pino'
+import chalk from 'chalk'
+import * as ws from 'ws'
+import { fileURLToPath } from 'url'
+import config from '../config.js';
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+let rtx = `✞ঔৣr̴ 𝘽𝙡𝙖𝙘𝙠 𝘾𝙡𝙤𝙫𝙚𝙧 - 𝙎𝙪𝙗 𝘽𝙤𝙩 𝙈𝙤𝙙𝙤 ঔৣ✞
+[⚙️] Conexión de Grimorio Sub-Bot: QR
+⚡ Invocación mágica inicializada... ☠️ Grimorio estableciendo vínculo espiritual...
+🜲 Escanea este código QR mágico desde otro 📱 o tu 🖥️ para convertirte en un ✧ Sub-Bot Temporal al servicio del Reino Mágico.
+📜 * Vinculación:
+1 » Toca los ⋮ tres puntos en la esquina superior derecha del WhatsApp
+2 » Selecciona Dispositivos Vinculados (Portal de Conexión)
+3 » Escanea el Grimorio QR para sincronizar tu alma con el bot
+⏳ ¡Alerta, Caballero Mágico! Este sello mágico se desvanece en ⚠️ 45 segundos...
+🧿 𝙎𝙄𝙎𝙏𝙀𝙈𝘼➤ [ QR ACTIVO ] 𝙀𝙎𝘾𝘼𝙉𝙀𝘼 𝙔𝘼 ⚔️`
+
+let rtx2 = `✞ঔৣr̴ 𝘽𝙡𝙖𝙘𝙠 𝙘𝙡𝙤𝙫𝙚𝙧 - 𝙎𝙪𝙗 𝘽𝙤𝙩 ঔৣ✞
+
+⌁ Conexión de Grimorio: CÓDIGO ⌁
+
+⚡ Canalizando energía arcana... ☠️ Grimorio despertando vínculo por código mágico...
+
+🜲 Usa este Código Espiritual para convertirte en un ✧ Sub-Bot Temporal bajo el contrato del Reino de las Sombras.
+
+📜 Vinculación Manual:
+
+1 » Pulsa los ⋮ tres puntos mágicos en la esquina superior derecha de WhatsApp
+2 » Selecciona Dispositivos Vinculados — Portal de Conexión
+3 » Elige Vincular con número de teléfono — Método del Grimorio Sellado
+4 » Introduce el Código Arcano otorgado por el núcleo mágico
+
+⏳ Atención, Guerrero de las Sombras: Este vínculo es delicado. ⚠️ No uses tu cuenta principal, emplea una réplica espiritual o una forma secundaria.
+
+🧿 𝙎𝙄𝙎𝙏𝙀𝙈𝘼 ➤ [ CÓDIGO LISTO ] — Activa el vínculo cuando estés preparado ⚔️`
+
+const maxSubBots = 500
+
+if (!global.conns) global.conns = []
+
+const cooldowns = new Map();
+
+function msToTime(duration) {
+  var seconds = Math.floor((duration / 1000) % 60),
+      minutes = Math.floor((duration / (1000 * 60)) % 60)
+  minutes = (minutes < 10) ? '0' + minutes : minutes
+  seconds = (seconds < 10) ? '0' + seconds : seconds
+  return minutes + ' m y ' + seconds + ' s '
+}
+
+export default {
+    name: 'qr',
+    aliases: ['code'],
+    category: 'subbots',
+    description: 'Conviértete en un sub-bot.',
+
+    async execute({ sock: conn, msg: m, args }) {
+        const userJid = m.sender;
+        const cooldownTime = 120000; // 2 minutes in ms
+
+        if (cooldowns.has(userJid)) {
+            const lastTime = cooldowns.get(userJid);
+            const timeDiff = Date.now() - lastTime;
+            if (timeDiff < cooldownTime) {
+                const timeLeft = cooldownTime - timeDiff;
+                return conn.sendMessage(m.key.remoteJid, { text: `⏳ Debes esperar ${msToTime(timeLeft)} para volver a vincular un *Sub-Bot.*` }, { quoted: m });
+            }
+        }
+
+        cooldowns.set(userJid, Date.now());
+
+        let body = m.message?.conversation || m.message?.extendedTextMessage?.text || '';
+        let command = body.trim().split(/ +/)[0].toLowerCase();
+        if (command.startsWith(config.prefix)) {
+            command = command.slice(config.prefix.length);
+        }
+
+        const subBots = [...new Set(
+            global.conns.filter(c =>
+            c.user && c.ws.socket && c.ws.socket.readyState !== ws.CLOSED
+            ).map(c => c)
+        )]
+
+        const subBotsCount = subBots.length
+
+        if (subBotsCount >= maxSubBots) {
+            return conn.sendMessage(m.key.remoteJid, { text: `❌ No se han encontrado espacios para *Sub-Bots* disponibles.` }, { quoted: m })
+        }
+
+        let who = m.sender;
+        let id = `${who.split('@')[0]}`
+        let pathblackJadiBot = path.join(process.cwd(), `./blackJadiBot/`, id)
+
+        if (!fs.existsSync(pathblackJadiBot)) {
+            fs.mkdirSync(pathblackJadiBot, { recursive: true })
+        }
+
+        let blackJBOptions = {}
+        blackJBOptions.pathblackJadiBot = pathblackJadiBot
+        blackJBOptions.m = m
+        blackJBOptions.conn = conn
+        blackJBOptions.args = args
+        blackJBOptions.usedPrefix = config.prefix
+        blackJBOptions.command = command
+        blackJBOptions.fromCommand = true
+
+        await blackJadiBot(blackJBOptions)
+    }
+}
+
+async function blackJadiBot(options) {
+  let { pathblackJadiBot, m, conn, args, usedPrefix, command } = options
+  if (command === 'code') {
+    command = 'qr'
+    args.unshift('code')
+  }
+  const mcode = args[0] && /(--code|code)/.test(args[0].trim())
+    ? true
+    : args[1] && /(--code|code)/.test(args[1].trim())
+      ? true
+      : false
+  let txtCode, codeBot, txtQR
+  if (mcode) {
+    args[0] = args[0].replace(/^--code$|^code$/, "").trim()
+    if (args[1]) args[1] = args[1].replace(/^--code$|^code$/, "").trim()
+    if (args[0] == "") args[0] = undefined
+  }
+  const pathCreds = path.join(pathblackJadiBot, "creds.json")
+  if (!fs.existsSync(pathblackJadiBot)) {
+    fs.mkdirSync(pathblackJadiBot, { recursive: true })
+  }
+  try {
+    if (args[0] && args[0] != undefined) {
+      fs.writeFileSync(pathCreds, JSON.stringify(JSON.parse(Buffer.from(args[0], "base64").toString("utf-8")), null, '\t'))
+    }
+  } catch {
+    conn.sendMessage(m.key.remoteJid, { text: `⚠️ Use correctamente el comando » ${usedPrefix + command}` }, { quoted: m })
+    return
+  }
+
+    const { version } = await fetchLatestBaileysVersion()
+    const msgRetry = () => { }
+    const msgRetryCache = new NodeCache()
+    const { state, saveCreds } = await useMultiFileAuthState(pathblackJadiBot)
+
+    const connectionOptions = {
+      logger: pino({ level: "fatal" }),
+      printQRInTerminal: false,
+      auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, pino({ level: 'silent' })) },
+      msgRetry,
+      msgRetryCache,
+      browser: mcode ? Browsers.macOS("Chrome") : Browsers.macOS("Desktop"),
+      version: version,
+      generateHighQualityLinkPreview: true
+    }
+
+    let sock = Baileys.default(connectionOptions)
+    sock.isInit = false
+    let isInit = true
+
+    async function connectionUpdate(update) {
+      const { connection, lastDisconnect, isNewLogin, qr } = update
+      if (isNewLogin) sock.isInit = false
+      if (qr && !mcode) {
+        if (m?.key.remoteJid) {
+          txtQR = await conn.sendMessage(m.key.remoteJid, { image: await qrcode.toBuffer(qr, { scale: 8 }), caption: rtx.trim() }, { quoted: m })
+        } else {
+          return
+        }
+        if (txtQR && txtQR.key) {
+          setTimeout(() => { conn.sendMessage(m.key.remoteJid, { delete: txtQR.key }) }, 30000)
+        }
+        return
+      }
+      if (qr && mcode) {
+        let secret = await sock.requestPairingCode((m.sender.split('@')[0]))
+        secret = secret.match(/.{1,4}/g)?.join("-")
+        txtCode = await conn.sendMessage(m.key.remoteJid, { text: rtx2 }, { quoted: m })
+        codeBot = await conn.sendMessage(m.key.remoteJid, { text: secret }, { quoted: m })
+        console.log(secret)
+      }
+      if (txtCode && txtCode.key) {
+        setTimeout(() => { conn.sendMessage(m.key.remoteJid, { delete: txtCode.key }) }, 30000)
+      }
+      if (codeBot && codeBot.key) {
+        setTimeout(() => { conn.sendMessage(m.key.remoteJid, { delete: codeBot.key }) }, 30000)
+      }
+
+      const creloadHandler = async function (restatConn) {
+        try {
+          const Handler = await import(`../handler.js?update=${Date.now()}`).catch(console.error)
+          if (Object.keys(Handler || {}).length) handlerModule = Handler
+
+        } catch (e) {
+          console.error('⚠️ Nuevo error: ', e)
+        }
+        if (restatConn) {
+          const oldChats = sock.chats
+          try { sock.ws.close() } catch { }
+          sock.ev.removeAllListeners()
+          sock = Baileys.default(connectionOptions, { chats: oldChats })
+          isInit = true
+        }
+        if (!isInit) {
+          sock.ev.off("messages.upsert", sock.handler)
+          sock.ev.off("connection.update", sock.connectionUpdate)
+          sock.ev.off('creds.update', sock.credsUpdate)
+        }
+
+        sock.handler = handlerModule.handler.bind(sock)
+        sock.connectionUpdate = connectionUpdate.bind(sock)
+        sock.credsUpdate = saveCreds.bind(sock, true)
+        sock.ev.on("messages.upsert", (msg) => sock.handler(msg, true));
+        sock.ev.on("connection.update", sock.connectionUpdate)
+        sock.ev.on("creds.update", sock.credsUpdate)
+        isInit = false
+        return true
+      }
+
+      const reason = lastDisconnect?.error?.output?.statusCode || lastDisconnect?.error?.output?.payload?.statusCode
+      if (connection === 'close') {
+        if (reason === 428 || reason === 408) {
+          console.log(chalk.bold.magentaBright(`\n╭─────────────────────────\n│ La conexión (+${path.basename(pathblackJadiBot)}) fue cerrada inesperadamente o expiró. Intentando reconectar...\n╰─────────────────────────`))
+          await creloadHandler(true).catch(console.error)
+        }
+        if (reason === 440) {
+          console.log(chalk.bold.magentaBright(`\n╭─────────────────────────\n│ La conexión (+${path.basename(pathblackJadiBot)}) fue reemplazada por otra sesión activa.\n╰─────────────────────────`))
+        }
+        if (reason == 405 || reason == 401) {
+          console.log(chalk.bold.magentaBright(`\n╭─────────────────────────\n│ La sesión (+${path.basename(pathblackJadiBot)}) fue cerrada. Credenciales no válidas o dispositivo desconectado manualmente.\n╰─────────────────────────`))
+          fs.rmdirSync(pathblackJadiBot, { recursive: true })
+        }
+        if (reason === 500) {
+          console.log(chalk.bold.magentaBright(`\n╭─────────────────────────\n│ Conexión perdida en la sesión (+${path.basename(pathblackJadiBot)}). Borrando datos...\n╰─────────────────────────`))
+          return creloadHandler(true).catch(console.error)
+        }
+        if (reason === 515) {
+          console.log(chalk.bold.magentaBright(`\n╭─────────────────────────\n│ Reinicio automático para la sesión (+${path.basename(pathblackJadiBot)}).\n╰─────────────────────────`))
+          await creloadHandler(true).catch(console.error)
+        }
+        if (reason === 403) {
+          console.log(chalk.bold.magentaBright(`\n╭─────────────────────────\n│ Sesión cerrada o cuenta en soporte para la sesión (+${path.basename(pathblackJadiBot)}).\n╰─────────────────────────`))
+          fs.rmdirSync(pathblackJadiBot, { recursive: true })
+        }
+      }
+      if (connection == 'open') {
+        let userName = sock.authState.creds.me.name || 'Anónimo'
+        let userJid = sock.authState.creds.me.jid || `${path.basename(pathblackJadiBot)}@s.whatsapp.net`
+        console.log(chalk.bold.cyanBright(`\n❒────────────【• SUB-BOT •】────────────❒\n│\n│ 🟢 ${userName} (+${path.basename(pathblackJadiBot)}) conectado exitosamente.\n│\n❒────────────【• CONECTADO •】────────────❒`))
+        sock.isInit = true
+        global.conns.push(sock)
+
+        if (m?.key.remoteJid) await conn.sendMessage(m.key.remoteJid, { text: args[0] ? `@${m.sender.split('@')[0]}, ya estás conectado, leyendo mensajes entrantes...` : `@${m.sender.split('@')[0]}, genial ya eres parte de nuestra familia de Sub-Bots.`, mentions: [m.sender] }, { quoted: m })
+      }
+    }
+
+    setInterval(async () => {
+      if (!sock.user) {
+        try { sock.ws.close() } catch { }
+        sock.ev.removeAllListeners()
+        let i = global.conns.indexOf(sock)
+        if (i < 0) return
+        delete global.conns[i]
+        global.conns.splice(i, 1)
+      }
+    }, 60000)
+
+    let handlerModule = await import(`../handler.js?update=${Date.now()}`);
+    let creloadHandler = async function (restatConn) {
+      try {
+        const Handler = await import(`../handler.js?update=${Date.now()}`).catch(console.error)
+        if (Object.keys(Handler || {}).length) handlerModule = Handler
+
+      } catch (e) {
+        console.error('⚠️ Nuevo error: ', e)
+      }
+      if (restatConn) {
+        const oldChats = sock.chats
+        try { sock.ws.close() } catch { }
+        sock.ev.removeAllListeners()
+        sock = Baileys.default(connectionOptions, { chats: oldChats })
+        isInit = true
+      }
+      if (!isInit) {
+        sock.ev.off("messages.upsert", sock.handler)
+        sock.ev.off("connection.update", sock.connectionUpdate)
+        sock.ev.off('creds.update', sock.credsUpdate)
+      }
+
+      sock.handler = handlerModule.handler.bind(sock)
+      sock.connectionUpdate = connectionUpdate.bind(sock)
+      sock.credsUpdate = saveCreds.bind(sock, true)
+      sock.ev.on("messages.upsert", (msg) => sock.handler(msg, true));
+      sock.ev.on("connection.update", sock.connectionUpdate)
+      sock.ev.on("creds.update", sock.credsUpdate)
+      isInit = false
+      return true
+    }
+    creloadHandler(false)
+}

--- a/plugins/serbot-list.js
+++ b/plugins/serbot-list.js
@@ -1,0 +1,97 @@
+import config from '../config.js';
+
+export default {
+    name: 'bots',
+    aliases: ['listjadibot'],
+    category: 'subbots',
+    description: 'Lista los sub-bots conectados.',
+
+    async execute({ sock: conn, msg: m }) {
+        const maxSubBots = 500;
+        const conns = Array.isArray(global.conns) ? global.conns : [];
+
+        const isConnOpen = (c) => {
+            try {
+                return c?.ws?.socket?.readyState === 1;
+            } catch {
+                return !!c?.user?.id;
+            }
+        };
+
+        const unique = new Map();
+        for (const c of conns) {
+            if (!c || !c.user) continue;
+            if (!isConnOpen(c)) continue;
+
+            const jidRaw = c.user.jid || c.user.id || '';
+            if (!jidRaw) continue;
+
+            unique.set(jidRaw, c);
+        }
+
+        const users = [...unique.values()];
+        const totalUsers = users.length;
+        const availableSlots = Math.max(0, maxSubBots - totalUsers);
+
+        const packname = '🤖 𝙱𝙾𝗧';
+        const title = `⭑『 𝗦𝗨𝗕𝗕𝗢𝗧𝗦 𝗖𝗢𝗡𝗘𝗖𝗧𝗔𝗗𝗢𝗦 』⭑`;
+        const barra = '━━━━━━━━━━━━━━━━';
+
+        let responseMessage = '';
+
+        if (totalUsers === 0) {
+            responseMessage = `╭═⬣ ${title}\n┃ 🔢 Total conectados: *0*\n┃ 🟢 Espacios disponibles: *${availableSlots}*\n╰═${barra}⬣\n\nNo hay subbots conectados por ahora.`;
+        } else if (totalUsers <= 15) {
+            const listado = users
+            .map((v, i) => {
+                const num = v.user.jid.replace(/[^0-9]/g, '');
+                const nombre = v?.user?.name || v?.user?.pushName || '👤 𝚂𝚄𝙱-𝙱𝙾𝗧';
+                const waLink = `https://wa.me/${num}?text=${config.prefix}code`;
+                return `╭╼⟪ ${packname} ⟫╾╮\n┃ #${i + 1} 👾 @${num}\n┃ 🌐 Link: ${waLink}\n┃ 🧠 Nombre: ${nombre}\n╰╼▣`;
+            })
+            .join('\n\n');
+
+            responseMessage = `╭═⬣ ${title}\n┃ 🔢 Total conectados: *${totalUsers}*\n┃ 🟢 Espacios disponibles: *${availableSlots}*\n╰═${barra}⬣\n\n${listado}`.trim();
+        } else {
+            responseMessage = `╭═⬣ ${title}\n┃ 🔢 Total conectados: *${totalUsers}*\n┃ 🟢 Espacios disponibles: *${availableSlots}*\n╰═${barra}⬣\n\n⚠️ Hay muchos subbots conectados, no se muestra la lista detallada.`;
+        }
+
+        responseMessage += `\n\n—\nCreador The Carlos 👑`;
+
+        const imageUrl = 'https://files.catbox.moe/1jkle5.jpg';
+
+        const fkontak = {
+            key: {
+                participants: "0@s.whatsapp.net",
+                remoteJid: "status@broadcast",
+                fromMe: false,
+                id: "Halo",
+            },
+            message: {
+                contactMessage: {
+                    displayName: "Subbot",
+                    vcard: "BEGIN:VCARD\nVERSION:3.0\nN:;Subbot;;;\nFN:Subbot\nEND:VCARD",
+                },
+            },
+        };
+
+        const mentions = [...new Set(
+            (responseMessage.match(/@(\d{5,16})/g) || []).map(v => v.replace('@', '') + '@s.whatsapp.net')
+        )];
+
+        try {
+            await conn.sendMessage(
+                m.key.remoteJid,
+                { image: { url: imageUrl }, caption: responseMessage, mentions },
+                { quoted: fkontak }
+            );
+        } catch (e) {
+            console.error('❌ Error enviando listado de subbots:', e);
+            await conn.sendMessage(
+                m.key.remoteJid,
+                { text: responseMessage, mentions },
+                { quoted: fkontak }
+            );
+        }
+    }
+}

--- a/plugins/serbot-token.js
+++ b/plugins/serbot-token.js
@@ -1,0 +1,23 @@
+import fs from 'fs'
+import path from 'path'
+
+export default {
+    name: 'token',
+    aliases: ['gettoken', 'serbottoken'],
+    category: 'subbots',
+    description: 'Obtiene el token de tu sesión de sub-bot.',
+
+    async execute({ sock: conn, msg: m }) {
+        const user = m.sender.split('@')[0]
+        const jadiBotPath = path.join(process.cwd(), 'blackJadiBot', user, 'creds.json');
+
+        if (fs.existsSync(jadiBotPath)) {
+            const token = Buffer.from(fs.readFileSync(jadiBotPath, 'utf-8')).toString('base64')
+
+            await conn.sendMessage(m.key.remoteJid, { text: `🍄 *El token te permite iniciar sesion en otros bots, recomendamos no compartirlo con nadie*\n\nTu token es:` }, { quoted: m });
+            await conn.sendMessage(m.key.remoteJid, { text: token }, { quoted: m });
+        } else {
+            await conn.sendMessage(m.key.remoteJid, { text: `🚩 *No tienes ningun token activo, usa !qr o !code para crear uno*` }, { quoted: m });
+        }
+    }
+}

--- a/plugins/serbot.js
+++ b/plugins/serbot.js
@@ -1,0 +1,120 @@
+import Baileys, { useMultiFileAuthState, DisconnectReason, makeCacheableSignalKeyStore, fetchLatestBaileysVersion, Browsers } from "@whiskeysockets/baileys"
+import qrcode from "qrcode"
+import fs from "fs"
+import path from "path"
+import pino from 'pino'
+import chalk from 'chalk'
+import { handler } from '../handler.js'
+import config from '../config.js';
+
+if (!global.subBots) global.subBots = [];
+const cooldowns = new Map();
+
+function msToTime(duration) {
+  var seconds = Math.floor((duration / 1000) % 60),
+      minutes = Math.floor((duration / (1000 * 60)) % 60)
+  minutes = (minutes < 10) ? '0' + minutes : minutes
+  seconds = (seconds < 10) ? '0' + seconds : seconds
+  return minutes + ' m y ' + seconds + ' s '
+}
+
+export default {
+    name: 'serbot',
+    aliases: ['qr', 'code'],
+    category: 'subbots',
+    description: 'Conviértete en un sub-bot.',
+
+    async execute({ sock: conn, msg: m, args }) {
+        const userJid = m.sender;
+        const cooldownTime = 120000; // 2 minutes
+
+        if (cooldowns.has(userJid)) {
+            const lastTime = cooldowns.get(userJid);
+            const timeDiff = Date.now() - lastTime;
+            if (timeDiff < cooldownTime) {
+                const timeLeft = cooldownTime - timeDiff;
+                return conn.sendMessage(m.key.remoteJid, { text: `⏳ Debes esperar ${msToTime(timeLeft)} para volver a ser un Sub-Bot.` }, { quoted: m });
+            }
+        }
+
+        const command = (m.message?.conversation || m.message?.extendedTextMessage?.text || '').trim().split(/ +/)[0].toLowerCase().slice(config.prefix.length);
+        const isCode = command === 'code' || args.includes('--code');
+
+        const subBotDir = path.join(process.cwd(), 'sub-bots', userJid.split('@')[0]);
+        if (fs.existsSync(subBotDir)) {
+            // Allow re-connecting by removing old session
+            fs.rmSync(subBotDir, { recursive: true, force: true });
+        }
+        fs.mkdirSync(subBotDir, { recursive: true });
+
+        const { state, saveCreds } = await useMultiFileAuthState(subBotDir);
+        const { version } = await fetchLatestBaileysVersion();
+
+        const connectionOptions = {
+            logger: pino({ level: "fatal" }),
+            printQRInTerminal: false,
+            auth: { creds: state.creds, keys: makeCacheableSignalKeyStore(state.keys, pino({ level: 'silent' })) },
+            browser: isCode ? Browsers.macOS("Chrome") : Browsers.macOS("Desktop"),
+            version: version,
+            generateHighQualityLinkPreview: true
+        };
+
+        const subBotSocket = Baileys.default(connectionOptions);
+
+        subBotSocket.ev.on('connection.update', async (update) => {
+            const { connection, lastDisconnect, qr } = update;
+
+            if (qr && !isCode) {
+                const qrImage = await qrcode.toBuffer(qr, { scale: 8 });
+                await conn.sendMessage(m.key.remoteJid, { image: qrImage, caption: "Escanea este QR para convertirte en un sub-bot." }, { quoted: m });
+            }
+
+            if (qr && isCode) {
+                try {
+                    let phoneNumber = userJid.split('@')[0];
+                    if (!phoneNumber) {
+                        await conn.sendMessage(m.key.remoteJid, { text: `No se pudo obtener tu número de teléfono para el código de emparejamiento.` }, { quoted: m });
+                        return;
+                    }
+                    await conn.sendMessage(m.key.remoteJid, { text: `Generando código para +${phoneNumber}...` }, { quoted: m });
+                    let secret = await subBotSocket.requestPairingCode(phoneNumber);
+                    secret = secret.match(/.{1,4}/g)?.join("-");
+                    await conn.sendMessage(m.key.remoteJid, { text: `Tu código de emparejamiento es: *${secret}*` }, { quoted: m });
+                } catch (e) {
+                    console.error(e);
+                    await conn.sendMessage(m.key.remoteJid, { text: `Error al generar el código. Intenta con el QR.` }, { quoted: m });
+                }
+            }
+
+            if (connection === 'open') {
+                cooldowns.set(userJid, Date.now());
+                const existingBotIndex = global.subBots.findIndex(bot => bot.jid === subBotSocket.user.id);
+                if (existingBotIndex > -1) {
+                    global.subBots.splice(existingBotIndex, 1);
+                }
+                global.subBots.push({ jid: subBotSocket.user.id, sock: subBotSocket, owner: userJid });
+                await conn.sendMessage(m.key.remoteJid, { text: `¡Felicidades! Ahora eres un sub-bot.` }, { quoted: m });
+            }
+
+            if (connection === 'close') {
+                const index = global.subBots.findIndex(bot => bot.jid === subBotSocket.user?.id);
+                if (index > -1) {
+                    global.subBots.splice(index, 1);
+                }
+
+                const shouldReconnect = (lastDisconnect.error)?.output?.statusCode !== DisconnectReason.loggedOut;
+                if (!shouldReconnect) {
+                    fs.rmdirSync(subBotDir, { recursive: true, force: true });
+                    await conn.sendMessage(m.key.remoteJid, { text: `Conexión de sub-bot cerrada permanentemente.` }, { quoted: m });
+                } else {
+                    // It will try to reconnect automatically
+                }
+            }
+        });
+
+        subBotSocket.ev.on('creds.update', saveCreds);
+        subBotSocket.ev.on('messages.upsert', (upsert) => {
+            handler.call(subBotSocket, upsert, true);
+        });
+    }
+}

--- a/plugins/token.js
+++ b/plugins/token.js
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import path from 'path'
+
+export default {
+    name: 'token',
+    aliases: ['gettoken'],
+    category: 'subbots',
+    description: 'Obtiene el token de tu sesión de sub-bot.',
+
+    async execute({ sock: conn, msg: m }) {
+        const userJid = m.sender;
+        const subBotDir = path.join(process.cwd(), 'sub-bots', userJid.split('@')[0]);
+        const credsPath = path.join(subBotDir, 'creds.json');
+
+        if (fs.existsSync(credsPath)) {
+            const token = Buffer.from(fs.readFileSync(credsPath, 'utf-8')).toString('base64');
+            await conn.sendMessage(userJid, { text: `Tu token de sesión es:\n\n\`\`\`${token}\`\`\`` });
+            if (m.key.remoteJid !== userJid) {
+                await conn.sendMessage(m.key.remoteJid, { text: "Te he enviado tu token por mensaje privado." }, { quoted: m });
+            }
+        } else {
+            await conn.sendMessage(m.key.remoteJid, { text: "No tienes una sesión de sub-bot activa. Usa el comando `serbot` para crear una." }, { quoted: m });
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new sub-bot feature that allows users to connect their own WhatsApp accounts as temporary bots.

The feature includes three new commands:
- `serbot` (with aliases `qr` and `code`): Creates a new sub-bot session by generating a QR code or a pairing code. The sub-bot sessions are stored in the `sub-bots/` directory.
- `bots` (with aliases `listbots` and `subbots`): Lists all currently connected sub-bots, showing their name, JID, and owner.
- `token` (with alias `gettoken`): Allows a user to retrieve their session token for their sub-bot, which is sent to them in a private message.

The implementation is done from scratch to ensure compatibility with the existing bot architecture and does not rely on the `simple.js` library. A global array `global.subBots` is used to manage active sub-bot connections.