### PR TITLE
fix: Revert change that broke the serbot command

### DIFF
--- a/plugins/serbot.js
+++ b/plugins/serbot.js
@@ -53,9 +53,7 @@ export default {
                     await conn.sendMessage(m.key.remoteJid, { text: `Generando código para +${phoneNumber}...` }, { quoted: m });
                     try {
                         const secret = await subBotSocket.requestPairingCode(phoneNumber);
-                        const formattedSecret = secret.match(/.{1,4}/g).join('-');
-                        await conn.sendMessage(m.key.remoteJid, { text: `Aquí está tu código de emparejamiento. Cópialo y pégalo en tu dispositivo.` }, { quoted: m });
-                        await conn.sendMessage(m.key.remoteJid, { text: formattedSecret }, { quoted: m });
+                        await conn.sendMessage(m.key.remoteJid, { text: `Tu código de emparejamiento es: *${secret.match(/.{1,4}/g).join('-')}*` }, { quoted: m });
                         pairingCodeRequested = true;
                     } catch (e) {
                         console.error("Error requesting pairing code:", e);


### PR DESCRIPTION
This commit reverts the previous change to the `serbot.js` plugin that attempted to split the pairing code message into two. The previous change caused the command to break.

This revert restores the command to its previous, working state, where it sends a single message containing the pairing code.