### PR TITLE
fix: Improve sub-bot connection logic to prevent timeout

### DIFF
--- a/plugins/serbot.js
+++ b/plugins/serbot.js
@@ -59,11 +59,11 @@ export default {
 
         const subBotSocket = Baileys.default(connectionOptions);
 
-        const waitForSocketOpen = async (timeoutMs = 30000) => {
+        const waitForConnection = async (timeoutMs = 60000) => {
             return new Promise((resolve, reject) => {
                 const start = Date.now();
                 const check = () => {
-                    if (subBotSocket.ws.readyState === 1) {
+                    if (subBotSocket.ws?.readyState === 1 && subBotSocket.authState?.creds?.noiseKey) {
                         resolve();
                     } else if (Date.now() - start > timeoutMs) {
                         reject(new Error("Timeout esperando la conexión del socket."));
@@ -110,7 +110,7 @@ export default {
                 mainHandler.call(subBotSocket, upsert, true);
             });
 
-            await waitForSocketOpen();
+            await waitForConnection();
 
             await conn.sendMessage(m.key.remoteJid, { text: `Generando código para +${phoneNumber}...` }, { quoted: m });
             const secret = await subBotSocket.requestPairingCode(phoneNumber);


### PR DESCRIPTION
This commit fixes a critical bug in the `serbot` command where the connection would time out before the pairing code could be requested.

The changes include:
- A new `waitForConnection` helper function that polls for a stable socket connection (`ws.readyState === 1` and the presence of `authState.creds.noiseKey`) before proceeding. This logic is inspired by the main bot's connection handler in `index.js`.
- The timeout for this connection check has been increased to 60 seconds to accommodate slower networks.
- `requestPairingCode` is now only called after `waitForConnection` resolves, preventing the "Connection Closed" error.

This makes the sub-bot creation process much more reliable and robust.